### PR TITLE
allow loading WOTLK/MOP m2s

### DIFF
--- a/m2_file.py
+++ b/m2_file.py
@@ -153,11 +153,13 @@ class M2File:
 
         elif self.version >= M2Versions.WOTLK:
 
-            if self.version >= M2Versions.WOD:
-                self.dependencies.lod_skins = ["{}{}.skin".format(
-                    self.raw_path, str(i + 1).zfill(2))  for i in range(2)]
-                self.dependencies.skins = ["{}{}.skin".format(
-                    self.raw_path, str(i).zfill(2)) for i in range(self.root.num_skin_profiles)]
+            # TODO : figure out if this is completely compatible with WOTLK
+            # if self.version >= M2Versions.WOD:
+            
+            self.dependencies.lod_skins = ["{}{}.skin".format(
+                self.raw_path, str(i + 1).zfill(2))  for i in range(2)]
+            self.dependencies.skins = ["{}{}.skin".format(
+                self.raw_path, str(i).zfill(2)) for i in range(self.root.num_skin_profiles)]
 
         # find textures
         for i, texture in enumerate(self.root.textures):


### PR DESCRIPTION
I don't know what was the reasoning for this, but the WOD skins loading seems to work well with WOTLK so far, and it's still better than not being able to load M2s at all.