### PR TITLE
fix M2CompBone size

### DIFF
--- a/file_formats/m2_format.py
+++ b/file_formats/m2_format.py
@@ -506,7 +506,7 @@ class M2CompBone:
 
     @staticmethod
     def size():
-        return 86 if M2VersionsManager().m2_version >= M2Versions.WOTLK else 110
+        return 88 if M2VersionsManager().m2_version >= M2Versions.WOTLK else 110
 
 
 #############################################################


### PR DESCRIPTION
M2CompBone use 88 bytes, at least in wotlk. Here's `Creatures/Centaur/Centaur.m2`. Note size used by template, it's an old one and a lot of fields are wrong but the numbers line up

![image](https://user-images.githubusercontent.com/76849026/150955781-18352f2d-594b-4ee4-8ef4-0498f131a856.png)
