### PR TITLE
wmo: add 'UseExteriorSky' flag to MOGPFlags

### DIFF
--- a/file_formats/wmo_format_group.py
+++ b/file_formats/wmo_format_group.py
@@ -11,6 +11,7 @@ class MOGPFlags:
     HasVertexColor = 0x4
     Outdoor = 0x8
     DoNotUseLocalLighting = 0x40
+    UseExteriorSky = 0x100
     HasLight = 0x200
     HasDoodads = 0x800
     HasWater = 0x1000


### PR DESCRIPTION
Titi added **UseExteriorSky** flag to WMOs, but because it isn't defined in pywowlib it gives an error when importing/exporting WMOs in Blender: `AttributeError: type object 'MOGPFlags' has no attribute 'UseExteriorSky'`

This fixes that error by adding the missing flag to the MOGPFlags class.